### PR TITLE
ensure country file is closed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ sourceSets {
 
 dependencies {
     implementation 'io.sentry:sentry:1.7.23'
-    implementation 'commons-io:commons-io:2.6'
     implementation 'org.apache.commons:commons-lang3:3.10'
     implementation 'javax.websocket:javax.websocket-api:1.1'
     implementation 'org.json:json:20190722'

--- a/src/de/gost0r/pickupbot/pickup/Country.java
+++ b/src/de/gost0r/pickupbot/pickup/Country.java
@@ -1,13 +1,12 @@
 package de.gost0r.pickupbot.pickup;
 
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 
-import org.apache.commons.io.IOUtils;
 import org.json.JSONArray;
 
 public class Country {
@@ -15,9 +14,8 @@ public class Country {
 	private static HashMap<String, String> CountryToContinentMap = new HashMap<String, String>();
 	
 	public static void initCountryCodes() throws IOException {
-		String fileName = Paths.get("country-and-continent-codes-list.json").toString();
-		InputStream is = new FileInputStream(fileName);
-		String jsonTxt = IOUtils.toString(is, "UTF-8");
+		Path filePath = Paths.get("country-and-continent-codes-list.json");
+		String jsonTxt = Files.readString(filePath, StandardCharsets.UTF_8);
 
 		JSONArray arr = new JSONArray(jsonTxt);
 		


### PR DESCRIPTION
Use `java.nio.file.Files#readString` introduced in Java 11 to ensure file is closed after reading. As a side effect, this removes the dependency on Apache Common IO.

Just a minor update, am assuming Java 11+ is the runtime used on the server.