### PR TITLE
Slash donate

### DIFF
--- a/src/main/java/de/gost0r/pickupbot/command/DonateCommand.java
+++ b/src/main/java/de/gost0r/pickupbot/command/DonateCommand.java
@@ -55,6 +55,7 @@ public class DonateCommand extends BaseCommand {
     @Override
     public void handle(DiscordSlashCommandInteraction interaction) {
         log.debug("Received donate command");
+        interaction.deferReply();
 
         OptionMapping donateUser = interaction.getOptions().stream().filter(o -> o.getName().equals(OPTION_PLAYER)).findFirst().orElse(null);
         OptionMapping amount = interaction.getOptions().stream().filter(o -> o.getName().equals(OPTION_AMOUNT)).findFirst().orElse(null);

--- a/src/main/java/de/gost0r/pickupbot/command/DonateCommand.java
+++ b/src/main/java/de/gost0r/pickupbot/command/DonateCommand.java
@@ -1,0 +1,87 @@
+package de.gost0r.pickupbot.command;
+
+import de.gost0r.pickupbot.command.common.BaseCommand;
+import de.gost0r.pickupbot.discord.*;
+import de.gost0r.pickupbot.discord.jda.JdaDiscordUser;
+import de.gost0r.pickupbot.pickup.Config;
+import de.gost0r.pickupbot.pickup.PickupBot;
+import de.gost0r.pickupbot.pickup.Player;
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+public class DonateCommand extends BaseCommand {
+
+    private static final String OPTION_PLAYER = "player";
+    private static final String OPTION_AMOUNT = "amount";
+
+    private final PickupBot bot;
+
+    public DonateCommand(PickupBot bot) {
+        this.bot = bot;
+    }
+
+    @Override
+    public void init() {
+        setApplicationCommand(
+                DiscordApplicationCommand
+                        .builder()
+                        .name("donate")
+                        .description("Donate pugcoins to another player privately")
+                        .options(List.of(
+                                DiscordCommandOption
+                                        .builder()
+                                        .type(DiscordCommandOptionType.USER)
+                                        .name(OPTION_PLAYER)
+                                        .description("Player to donate to")
+                                        .required(true)
+                                        .build(),
+                                DiscordCommandOption
+                                        .builder()
+                                        .type(DiscordCommandOptionType.INTEGER)
+                                        .name(OPTION_AMOUNT)
+                                        .description("Amount of pugcoins to donate")
+                                        .required(true)
+                                        .build()
+                        ))
+                        .build()
+        );
+    }
+
+    @Override
+    public void handle(DiscordSlashCommandInteraction interaction) {
+        log.debug("Received donate command");
+
+        OptionMapping donateUser = interaction.getOptions().stream().filter(o -> o.getName().equals(OPTION_PLAYER)).findFirst().orElse(null);
+        OptionMapping amount = interaction.getOptions().stream().filter(o -> o.getName().equals(OPTION_AMOUNT)).findFirst().orElse(null);
+
+        if (donateUser == null || amount == null) {
+            interaction.respondEphemeral("Invalid arguments");
+            return;
+        }
+
+        Player player = Player.get(interaction.getUser());
+        if (player == null) {
+            interaction.respondEphemeral(Config.user_not_registered);
+            return;
+        }
+
+        DiscordUser destDiscordUser = new JdaDiscordUser(donateUser.getAsMember(), donateUser.getAsUser());
+        Player destPlayer = Player.get(destDiscordUser);
+        if (destPlayer == null) {
+            interaction.respondEphemeral(Config.player_not_found);
+            return;
+        }
+
+        if (player.equals(destPlayer)) {
+            interaction.respondEphemeral("You cannot donate to yourself.");
+            return;
+        }
+
+        bot.getLogic().donatePlayer(interaction, player, destPlayer, amount.getAsInt());
+    }
+}

--- a/src/main/java/de/gost0r/pickupbot/pickup/Config.java
+++ b/src/main/java/de/gost0r/pickupbot/pickup/Config.java
@@ -29,7 +29,6 @@ public class Config {
     public static final String CMD_ADDVOTE = "!addvote";
     public static final String CMD_BANMAP = "!banmap";
     public static final String CMD_WALLET = "!wallet";
-    public static final String CMD_DONATE = "!donate";
     public static final String CMD_BETHISTORY = "!bethistory";
 
     public static final String CMD_LOCK = "!lock";
@@ -113,7 +112,7 @@ public class Config {
             + " " + CMD_MAPS + " " + CMD_MAP + " " + CMD_MATCH + " " + CMD_LAST + " " + CMD_LIVE + " " + CMD_STATUS + " " + CMD_HELP
             + " " + CMD_GETELO + " " + CMD_GETSTATS + " " + CMD_TOP_PLAYERS + " " + CMD_TOP_COUNTRIES + " " + CMD_TOP_KDR + " " + CMD_TOP_WDL
             + " " + CMD_SURRENDER + " " + CMD_BANINFO + " " + CMD_VOTES + " " + CMD_LAST + " " + CMD_TEAM + " " + CMD_LEAVETEAM + " " + CMD_SCRIM
-            + " " + CMD_REMOVETEAM + " " + CMD_TEAMS + " " + CMD_WALLET + " " + CMD_DONATE + " " + CMD_BETHISTORY + " " + CMD_TOP_RICH
+            + " " + CMD_REMOVETEAM + " " + CMD_TEAMS + " " + CMD_WALLET + " " + CMD_BETHISTORY + " " + CMD_TOP_RICH
             + " " + CMD_CREATE_PRIVATE + " " + CMD_PRIVATE + " " + CMD_ADD_PLAYER_PRIVATE + " " + CMD_REMOVE_PLAYER_PRIVATE + " " + CMD_LEAVE_PRIVATE
             + " " + CMD_SHOW_PRIVATE;
 
@@ -207,8 +206,6 @@ public class Config {
     public static final String USE_CMD_TEAM = "!team <@user1> <@user2> <...>";
     public static final String USE_CMD_LEAVETEAM = "!leaveteam removes you from your current team";
     public static final String USE_CMD_TEAMS = "!teams lists the active teams";
-
-    public static final String USE_CMD_DONATE = "!donate <player> <amount>";
 
     public static final String USE_CMD_CREATE_PRIVATE = "!createprivate <gamemode> <players (optional)>";
     public static final String USE_CMD_ADD_PLAYER_PRIVATE = "!addprivate <players>";

--- a/src/main/java/de/gost0r/pickupbot/pickup/PickupBot.java
+++ b/src/main/java/de/gost0r/pickupbot/pickup/PickupBot.java
@@ -627,32 +627,6 @@ public class PickupBot {
 
                     } else msg.reply(Config.user_not_registered);
                     break;
-                case Config.CMD_DONATE:
-                    if (p != null) {
-                        if (data.length == 3) {
-
-                            Player pOther;
-                            DiscordUser u = discordService.getUserFromMention(data[1]);
-                            if (u != null) {
-                                pOther = Player.get(u);
-                            } else {
-                                pOther = Player.get(data[1].toLowerCase());
-                            }
-
-                            if (pOther != null) {
-                                int amount;
-                                try {
-                                    amount = Integer.parseInt(data[2]);
-                                    logic.cmdDonate(p, pOther, amount).replyTo(msg);
-                                } catch (NumberFormatException nfe) {
-                                    msg.reply(Config.donate_incorrect_amount);
-                                }
-                            } else msg.reply(Config.player_not_found);
-                        } else
-                            msg.reply(Config.wrong_argument_amount.replace(".cmd.", Config.USE_CMD_DONATE));
-
-                    } else msg.reply(Config.user_not_registered);
-                    break;
                 case Config.CMD_BETHISTORY:
                     if (p != null) {
                         if (data.length == 1) {

--- a/src/main/java/de/gost0r/pickupbot/pickup/PickupLogic.java
+++ b/src/main/java/de/gost0r/pickupbot/pickup/PickupLogic.java
@@ -2788,15 +2788,18 @@ public class PickupLogic {
         return new PickupReply(msg);
     }
 
-    public PickupReply cmdDonate(Player p, Player destP, int amount) {
+    public void donatePlayer(DiscordSlashCommandInteraction interaction, Player p, Player destP, int amount) {
         if (amount <= 0) {
-            return new PickupReply(Config.donate_incorrect_amount);
+            interaction.respondEphemeral(Config.donate_incorrect_amount);
+            return;
         }
         if (amount > 10000) {
-            return new PickupReply(Config.donate_above_limit);
+            interaction.respondEphemeral(Config.donate_above_limit);
+            return;
         }
         if (amount > p.getCoins()) {
-            return new PickupReply(Config.bets_insufficient);
+            interaction.respondEphemeral(Config.bets_insufficient);
+            return;
         }
 
         p.spendCoins(amount);
@@ -2811,9 +2814,9 @@ public class PickupLogic {
         msg = msg.replace(".amount.", String.format("%,d", amount));
         msg = msg.replace(".emojiname.", coinEmoji.name());
         msg = msg.replace(".emojiid.", coinEmoji.id());
-        bot.sendMsg(getChannelByType(PickupChannelType.PUBLIC), msg);
-
-        return PickupReply.NONE;
+        
+        interaction.respondEphemeral(msg);
+        destP.getDiscordUser().sendPrivateMessage(msg);
     }
 
     public PickupReply cmdBetHistory(Player p) {

--- a/src/test/java/de/gost0r/pickupbot/pickup/PickupLogicTest.java
+++ b/src/test/java/de/gost0r/pickupbot/pickup/PickupLogicTest.java
@@ -264,19 +264,27 @@ class PickupLogicTest {
     @Test void donate_transfersCoins() {
         var from = players.get("charlie");
         var to = players.get("delta");
-        long before = from.getCoins();
-        logic.cmdDonate(from, to, 100);
-        assertEquals(before - 100, from.getCoins());
+        long beforeFrom = from.getCoins();
+        long beforeTo = to.getCoins();
+        var interaction = mock(DiscordSlashCommandInteraction.class);
+
+        logic.donatePlayer(interaction, from, to, 100);
+
+        assertEquals(beforeFrom - 100, from.getCoins());
+        assertEquals(beforeTo + 100, to.getCoins());
+        verify(interaction).respondEphemeral(contains("donated"));
     }
 
     @Test void donate_overLimit_rejected() {
-        var r = logic.cmdDonate(players.get("echo"), players.get("foxtrot"), 20_000);
-        assertEquals(Config.donate_above_limit, r.getMessage());
+        var interaction = mock(DiscordSlashCommandInteraction.class);
+        logic.donatePlayer(interaction, players.get("echo"), players.get("foxtrot"), 20_000);
+        verify(interaction).respondEphemeral(Config.donate_above_limit);
     }
 
     @Test void donate_insufficientFunds_rejected() {
-        var r = logic.cmdDonate(players.get("india"), players.get("juliet"), 5_000);
-        assertEquals(Config.bets_insufficient, r.getMessage());
+        var interaction = mock(DiscordSlashCommandInteraction.class);
+        logic.donatePlayer(interaction, players.get("india"), players.get("juliet"), 5_000);
+        verify(interaction).respondEphemeral(Config.bets_insufficient);
     }
 
     // ========== pardonPlayer (slash command) ==========


### PR DESCRIPTION
This migrates the donate command to a slash command to prevent channel spam. The bot now replies ephemerally to the sender and sends a private message to the receiver, ensuring the transaction remains private.